### PR TITLE
Improve terminal UX with help and clear commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <title>Justin PuffPaff – Retro 3D Resume + Python Games + Easter Eggs</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
   <!-- Load Pyodide from CDN for .py usage -->
   <script src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"></script>
@@ -57,6 +60,8 @@
         <li><strong>snake up</strong>, <strong>pong left</strong>, <strong>invaders shoot</strong>, etc.</li>
         <li><strong>python-calc 2+2</strong> – Calculator</li>
         <li><strong>egg1</strong> – Reveal a special 3D Easter Egg #1</li>
+        <li><strong>help</strong> – List available commands</li>
+        <li><strong>clear</strong> – Clear the terminal output</li>
         <li><strong>dnd start</strong>, <strong>dnd explore</strong>, <strong>dnd fight</strong>, <strong>dnd status</strong>, <strong>dnd potion</strong> – Epic D&D Text Adventure!</li>
         <li><strong>wizard start</strong>, <strong>wizard look</strong>, <strong>wizard go [direction]</strong>, <strong>wizard take</strong>, <strong>wizard use [item]</strong>, <strong>wizard attack</strong> – Play 'The Cavern of the Evil Wizard'</li>
       </ul>

--- a/scripts.js
+++ b/scripts.js
@@ -239,6 +239,14 @@ function handleCommand(cmd) {
       warningOverlay.style.display = 'flex';
       break;
 
+    case 'help':
+      linesContainer.textContent += "\nAvailable commands:\nstart, pause, continue, end, python-game, python-calc, python-snake, python-pong, python-invaders, python-adventure, egg1, egg2, egg5, clear, help\n";
+      break;
+
+    case 'clear':
+      linesContainer.textContent = '';
+      break;
+
     // --------------------------------------
     // PYTHON GAMES
     // --------------------------------------

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,7 @@
 body {
   background: #000;
   color: #0f0;
-  font-family: 'Courier New', Courier, monospace;
+  font-family: 'Fira Code', 'Courier New', Courier, monospace;
   min-height: 200vh;
   overflow-x: hidden;
 }
@@ -218,9 +218,16 @@ body {
   height: 36%;
   background: #000;
   border: 1px solid #0f0;
+  border-radius: 4px;
+  box-shadow: 0 0 20px rgba(0,255,0,0.4);
   overflow: hidden;
   display: flex;
   flex-direction: column;
+  transition: box-shadow 0.3s ease;
+}
+
+.monitor-screen:hover {
+  box-shadow: 0 0 30px rgba(0,255,0,0.7);
 }
 .monitor-fade {
   position: absolute;
@@ -285,6 +292,11 @@ body {
   font-family: inherit;
   font-size: 1rem;
   caret-color: #0f0;
+  transition: box-shadow 0.2s ease;
+}
+
+#commandInput:focus {
+  box-shadow: 0 0 5px #0f0;
 }
 
 /* PASSCODE OVERLAY */


### PR DESCRIPTION
## Summary
- Add Google Fira Code font and include help/clear in command list
- Introduce `help` and `clear` terminal commands
- Refine monitor screen and input focus styling for sleeker look

## Testing
- `python -m py_compile game.py`


------
https://chatgpt.com/codex/tasks/task_e_68b75345a268833094062cd6af4da1b9